### PR TITLE
fix: remove a stale BKPUPD-NEXT-BOOT-TASK before re-adding it

### DIFF
--- a/BackupAndUpdate.rsc
+++ b/BackupAndUpdate.rsc
@@ -602,6 +602,13 @@
       }
 
       :local scheduledCommand (":delay 5s; /system scheduler remove BKPUPD-NEXT-BOOT-TASK; :global buGlobalVarScriptStep $nextStep; :global buGlobalVarTargetOsVersion \"$routerOsVersionAvailable\"; :delay 10s; /system script run BackupAndUpdate;")
+
+      # Drop a leftover task from an interrupted update cycle. Without this the
+      # add below fails with `already have such name`, which aborts this block
+      # before `/system package update install` is reached and is then reported
+      # as "Failed to install new RouterOS version".
+      :do {/system scheduler remove BKPUPD-NEXT-BOOT-TASK} on-error={}
+
       /system scheduler add name=BKPUPD-NEXT-BOOT-TASK on-event=$scheduledCommand start-time=startup interval=0
 
       /system package update install
@@ -635,6 +642,12 @@
   :log info "$SMP routerboard upgrade process was completed, going to reboot in a moment!"
 
   ## Set task to send final report on the next boot
+  # Drop a leftover task from an interrupted update cycle (see step 1). This add
+  # is not wrapped in `:do`, so a name collision here kills the script before
+  # `/system reboot` and leaves the device on the new RouterOS with the old
+  # routerboard firmware and no final report.
+  :do {/system scheduler remove BKPUPD-NEXT-BOOT-TASK} on-error={}
+
   /system scheduler add name=BKPUPD-NEXT-BOOT-TASK on-event=":delay 5s; /system scheduler remove BKPUPD-NEXT-BOOT-TASK; :global buGlobalVarScriptStep 3; :global buGlobalVarTargetOsVersion \"$buGlobalVarTargetOsVersion\"; :delay 10s; /system script run BackupAndUpdate;" start-time=startup interval=0
 
   /system reboot

--- a/BackupAndUpdate.rsc
+++ b/BackupAndUpdate.rsc
@@ -603,10 +603,7 @@
 
       :local scheduledCommand (":delay 5s; /system scheduler remove BKPUPD-NEXT-BOOT-TASK; :global buGlobalVarScriptStep $nextStep; :global buGlobalVarTargetOsVersion \"$routerOsVersionAvailable\"; :delay 10s; /system script run BackupAndUpdate;")
 
-      # Drop a leftover task from an interrupted update cycle. Without this the
-      # add below fails with `already have such name`, which aborts this block
-      # before `/system package update install` is reached and is then reported
-      # as "Failed to install new RouterOS version".
+      # Drop a leftover task from an interrupted update cycle, otherwise the add below fails
       :do {/system scheduler remove BKPUPD-NEXT-BOOT-TASK} on-error={}
 
       /system scheduler add name=BKPUPD-NEXT-BOOT-TASK on-event=$scheduledCommand start-time=startup interval=0
@@ -642,10 +639,7 @@
   :log info "$SMP routerboard upgrade process was completed, going to reboot in a moment!"
 
   ## Set task to send final report on the next boot
-  # Drop a leftover task from an interrupted update cycle (see step 1). This add
-  # is not wrapped in `:do`, so a name collision here kills the script before
-  # `/system reboot` and leaves the device on the new RouterOS with the old
-  # routerboard firmware and no final report.
+  # Drop a leftover task from an interrupted update cycle, otherwise the add below fails and the device never reboots
   :do {/system scheduler remove BKPUPD-NEXT-BOOT-TASK} on-error={}
 
   /system scheduler add name=BKPUPD-NEXT-BOOT-TASK on-event=":delay 5s; /system scheduler remove BKPUPD-NEXT-BOOT-TASK; :global buGlobalVarScriptStep 3; :global buGlobalVarTargetOsVersion \"$buGlobalVarTargetOsVersion\"; :delay 10s; /system script run BackupAndUpdate;" start-time=startup interval=0


### PR DESCRIPTION
Fixes #83

A leftover `BKPUPD-NEXT-BOOT-TASK` from an interrupted update cycle makes
`/system scheduler add` fail with `already have such name`. In `STEP 1` that
aborts the surrounding `:do` block **before `/system package update install` is
reached**, so no update happens, and the `on-error` handler reports
`Failed to install new RouterOS version` for an install that never ran. The
handler then clears the leftover, so the next scheduled run works — which makes
the fault self-healing and easy to misdiagnose as a network or mirror problem.

`STEP 2` has the same collision but no `:do` around it, so a clash there kills
the script before `/system reboot`, leaving the device on the new RouterOS with
the old routerboard firmware and no final report.

## Change

Two guarded removes, one before each `add`, using the same idiom the script
already uses in its error handler:

```rsc
:do {/system scheduler remove BKPUPD-NEXT-BOOT-TASK} on-error={}
```

13 added lines in `BackupAndUpdate.rsc`, nothing else touched. `scriptVersion`
is deliberately left alone — that is yours to bump.

## Verification

- The name collision raises an error on RouterOS 7.23.3 (checked directly on a
  CCR2004-16G-2S+).
- The patched script runs cleanly on five devices — CCR2004-16G-2S+, CRS312-4C+8XG,
  CRS328-24P-4S+, CRS354-48P-4S+2Q+ and a hAP ac — all on RouterOS 7.23.3, in
  `osupdate` mode.
- Production log evidence of the failing run and the succeeding run the next day
  is in the issue.
- **Not verified:** the full failing → fixed update cycle end to end. That needs
  an actual pending RouterOS release; the next one will be the real test.
