### PR TITLE
fix: wait for the update check to finish instead of a fixed delay

### DIFF
--- a/BackupAndUpdate.rsc
+++ b/BackupAndUpdate.rsc
@@ -478,10 +478,21 @@
     :log info ("$SMP Checking for new RouterOS version. Current installed version is: `$runningOsVersion`")
     /system package update check-for-updates
 
-    # Wait to allow the system to check for updates
-    :delay 5s
-
+    # `check-for-updates` is asynchronous, so a fixed delay races it.
+    # Wait for a terminal status instead, with a timeout as the fallback.
     :local packageUpdateStatus "undefined"
+    :local checkTimeout 60
+    :local checkCounter 0
+    :delay 2s
+    :while ($checkCounter < $checkTimeout) do={
+      :set packageUpdateStatus [/system package update get status]
+      :if ($packageUpdateStatus = "New version is available" or $packageUpdateStatus = "System is already up to date") do={
+        :set checkCounter $checkTimeout
+      } else={
+        :delay 1s
+        :set checkCounter ($checkCounter + 1)
+      }
+    }
 
     :set routerOsVersionAvailable [/system package update get latest-version]
     :set packageUpdateStatus [/system package update get status]


### PR DESCRIPTION
`/system package update check-for-updates` runs asynchronously. The fixed
`:delay 5s` races it: on this fleet the check regularly needs longer, so
`status` is still `finding out latest version...` when it is read, and the run
aborts with `Failed to check for new RouterOS version`.

Poll for a terminal status instead, capped at 60 seconds. Keyed on the two END
states rather than the in-progress text, so an unknown status runs into the
timeout and is reported by the existing error branch instead of exiting early.

Verified on RouterOS 7.24 on CCR2004-16G-2S+, CRS328-24P-4S+, CRS312-4C+8XG and
a hAP ac, all in `osupdate` mode. `scriptVersion` deliberately left alone.
