### PR TITLE
fix: make the config export version-aware on both branches

### DIFF
--- a/BackupAndUpdate.rsc
+++ b/BackupAndUpdate.rsc
@@ -165,23 +165,45 @@
   :log info ("$SMP system backup created: `$backupFileSys`")
 
     ## Export config file
+  # RouterOS parses the whole script before running it, so a version specific command has to
+  # stay inside a string and be run with `:execute`. Otherwise the branch the running version
+  # does not support breaks parsing and nothing runs at all.
+  :local osMajor 7
+  :local osVersionRaw [/system resource get version]
+  :local osVersionDotPos [:find $osVersionRaw "."]
+  :if ([:len $osVersionDotPos] > 0) do={
+    :set osMajor [:tonum [:pick $osVersionRaw 0 $osVersionDotPos]]
+  }
+
   :if ($sensitiveDataInConfig = true) do={
     :log info ("$SMP starting export config with sensitive data, backup name: `$backupName`")
     # Since RouterOS v7 it needs to be explicitly set that we want to export sensitive data
-    :if ([:pick [/system resource get version] 0 1] < 7) do={
+    :if ($osMajor < 7) do={
       :execute "/export compact terse file=$backupName"
     } else={
       :execute "/export compact show-sensitive terse file=$backupName"
     }
   } else={
     :log info ("$SMP starting export config without sensitive data, backup name: `$backupName`")
-    /export compact hide-sensitive terse file=$backupName
+    :if ($osMajor < 7) do={
+      :execute "/export compact hide-sensitive terse file=$backupName"
+    } else={
+      # Since RouterOS v7 sensitive data is hidden by default
+      :execute "/export compact terse file=$backupName"
+    }
   }
 
   :log info ("$SMP Config export complete: `$backupFileConfig`")
-  :log info ("$SMP Waiting a little to ensure backup files are written")
+  :log info ("$SMP Waiting for the backup files to be written")
 
-  :delay 40s
+  # Both export branches run asynchronously via `:execute`, so wait for the files to appear
+  # instead of relying on a fixed delay.
+  :local waitBackupTimeout 120
+  :local waitBackupCounter 0
+  :while ($waitBackupCounter < $waitBackupTimeout and ([:len [/file find name=$backupFileSys]] = 0 or [:len [/file find name=$backupFileConfig]] = 0)) do={
+    :delay 1s
+    :set waitBackupCounter ($waitBackupCounter + 1)
+  }
 
   :if ([:len [/file find name=$backupFileSys]] > 0) do={
     :log info ("$SMP system backup file successfully saved to the file system: `$backupFileSys`")


### PR DESCRIPTION
Fixes the crash reported in #87: on RouterOS v7 the script stops before creating any backup when `sensitiveDataInConfig` is set to `false`.

### The bug

RouterOS syntax-checks the whole script when it is parsed, not lazily when a branch is reached, so one token the running version rejects stops everything. That is why the `sensitiveDataInConfig = true` path was already wrapped in `:execute` - a command kept inside a string is not parsed until it runs, so a v6 box never parses `show-sensitive` and a v7 box never parses a v6-only form.

The `else` branch was the one place a version-specific command was still written as a literal:

```
/export compact hide-sensitive terse file=$backupName
```

It is now version-aware and goes through `:execute` like the other branch.

### Also in this PR

- **Major-version parsing.** `[:pick [/system resource get version] 0 1] < 7` picks a single character and compares a string against a number. It happens to work for 6 vs 7 and silently breaks at RouterOS 10. Replaced with a parse of the major version, applied to both branches.
- **Wait for the files instead of `:delay 40s`.** With both branches now asynchronous, the fixed delay was the only thing between the export and the `/file find` check; on a large config that is a race, and losing it surfaces as the misleading `config backup was not created`. Replaced with a poll (120s cap) on the two backup files, which also makes the common case faster. Same shape as the fix already applied to `check-for-updates` in #85.

### Open question, deliberately not resolved here

@Magic-VK reported the crash on 7.23.1 and attributed it to `hide-sensitive` having been removed in v7. I do not think that is the cause: `hide-sensitive` is still accepted in v7 and is simply a no-op, since hiding is the default. If 7.23 really rejects it, that is a 7.23-specific change worth documenting. Either way this patch is correct, because the v7 path never uses `hide-sensitive`.

The one-liner that settles it, on an unpatched 7.23/7.24 box:

```
/export compact hide-sensitive terse file=hide-test
```

Happy to add the finding to the PR description once it is run.

### Scope

Bug fix only. The log export discussed in #87 is a feature and carries an unsanitised-attachment question of its own, so it belongs in a separate proposal.

Co-authored with @Magic-VK, whose version-aware `else` block and file poll are the basis of this patch.
